### PR TITLE
allegro_hand_description: Place xacro macro defs before usage

### DIFF
--- a/src/allegro_hand_description/allegro_hand_description_left.xacro
+++ b/src/allegro_hand_description/allegro_hand_description_left.xacro
@@ -81,42 +81,6 @@
     </link>
 
     <!-- ============================================================================= -->
-    <!-- FINGERS -->
-    <!-- RIGHT HAND due to which finger is number 0 -->
-    <!-- for LEFT HAND switch the sign of the **offset_origin_y** and **finger_angle_r** parameters-->
-    <xacro:finger
-            finger_num="2"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="${offset_origin_y_const}"
-            offset_origin_z="${offset_origin_z_const}"
-            finger_angle_r="-${5.0*DEG2RAD}"
-            />
-    <xacro:finger
-            finger_num="1"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="0"
-            offset_origin_z="${offset_origin_z_mid_const}"
-            finger_angle_r="0.0"
-            />
-    <xacro:finger
-            finger_num="0"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="-${offset_origin_y_const}"
-            offset_origin_z="${offset_origin_z_const}"
-            finger_angle_r="${5.0*DEG2RAD}"
-            />
-    <!-- THUMB -->
-    <xacro:thumb_left
-            finger_num="3"
-            offset_origin_x="-0.0182"
-            offset_origin_y="-0.019333"
-            offset_origin_z="-0.045987"
-            finger_angle_r="0"
-            finger_angle_p="-${95*DEG2RAD}"
-            finger_angle_y="${90*DEG2RAD}"
-            />
-
-    <!-- ============================================================================= -->
 
     <!-- THUMB MACRO -->
     <xacro:macro name="thumb_left"
@@ -491,4 +455,40 @@
         </joint>
     </xacro:macro>
     <!-- [[END]] THREE FINGER MACRO -->
+
+    <!-- ============================================================================= -->
+    <!-- FINGERS -->
+    <!-- RIGHT HAND due to which finger is number 0 -->
+    <!-- for LEFT HAND switch the sign of the **offset_origin_y** and **finger_angle_r** parameters-->
+    <xacro:finger
+            finger_num="2"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="${offset_origin_y_const}"
+            offset_origin_z="${offset_origin_z_const}"
+            finger_angle_r="-${5.0*DEG2RAD}"
+            />
+    <xacro:finger
+            finger_num="1"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="0"
+            offset_origin_z="${offset_origin_z_mid_const}"
+            finger_angle_r="0.0"
+            />
+    <xacro:finger
+            finger_num="0"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="-${offset_origin_y_const}"
+            offset_origin_z="${offset_origin_z_const}"
+            finger_angle_r="${5.0*DEG2RAD}"
+            />
+    <!-- THUMB -->
+    <xacro:thumb_left
+            finger_num="3"
+            offset_origin_x="-0.0182"
+            offset_origin_y="-0.019333"
+            offset_origin_z="-0.045987"
+            finger_angle_r="0"
+            finger_angle_p="-${95*DEG2RAD}"
+            finger_angle_y="${90*DEG2RAD}"
+            />
 </robot>

--- a/src/allegro_hand_description/allegro_hand_description_right.xacro
+++ b/src/allegro_hand_description/allegro_hand_description_right.xacro
@@ -81,42 +81,6 @@
     </link>
 
     <!-- ============================================================================= -->
-    <!-- FINGERS -->
-    <!-- RIGHT HAND due to which finger is number 0 -->
-    <!-- for LEFT HAND switch the sign of the **offset_origin_y** and **finger_angle_r** parameters-->
-    <xacro:finger
-            finger_num="0"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="${offset_origin_y_const}"
-            offset_origin_z="${offset_origin_z_const}"
-            finger_angle_r="-${5.0*DEG2RAD}"
-            />
-    <xacro:finger
-            finger_num="1"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="0"
-            offset_origin_z="${offset_origin_z_mid_const}"
-            finger_angle_r="0.0"
-            />
-    <xacro:finger
-            finger_num="2"
-            offset_origin_x="${offset_origin_x_const}"
-            offset_origin_y="-${offset_origin_y_const}"
-            offset_origin_z="${offset_origin_z_const}"
-            finger_angle_r="${5.0*DEG2RAD}"
-            />
-    <!-- THUMB -->
-    <xacro:thumb_right
-            finger_num="3"
-            offset_origin_x="-0.0182"
-            offset_origin_y="0.019333"
-            offset_origin_z="-0.045987"
-            finger_angle_r="0"
-            finger_angle_p="-${95*DEG2RAD}"
-            finger_angle_y="-${90*DEG2RAD}"
-            />
-
-    <!-- ============================================================================= -->
 
     <!-- THUMB MACRO -->
     <xacro:macro name="thumb_right"
@@ -489,4 +453,40 @@
         </joint>
     </xacro:macro>
     <!-- [[END]] THREE FINGER MACRO -->
+
+    <!-- ============================================================================= -->
+    <!-- FINGERS -->
+    <!-- RIGHT HAND due to which finger is number 0 -->
+    <!-- for LEFT HAND switch the sign of the **offset_origin_y** and **finger_angle_r** parameters-->
+    <xacro:finger
+            finger_num="0"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="${offset_origin_y_const}"
+            offset_origin_z="${offset_origin_z_const}"
+            finger_angle_r="-${5.0*DEG2RAD}"
+            />
+    <xacro:finger
+            finger_num="1"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="0"
+            offset_origin_z="${offset_origin_z_mid_const}"
+            finger_angle_r="0.0"
+            />
+    <xacro:finger
+            finger_num="2"
+            offset_origin_x="${offset_origin_x_const}"
+            offset_origin_y="-${offset_origin_y_const}"
+            offset_origin_z="${offset_origin_z_const}"
+            finger_angle_r="${5.0*DEG2RAD}"
+            />
+    <!-- THUMB -->
+    <xacro:thumb_right
+            finger_num="3"
+            offset_origin_x="-0.0182"
+            offset_origin_y="0.019333"
+            offset_origin_z="-0.045987"
+            finger_angle_r="0"
+            finger_angle_p="-${95*DEG2RAD}"
+            finger_angle_y="-${90*DEG2RAD}"
+            />
 </robot>


### PR DESCRIPTION
Without this change, I get the following error:
```
$ roslaunch allegro_hand allegro_hand.launch HAND:=right <...>
...
unknown macro name: finger
when processing file: {pwd}/allegro_hand_ros_catkin/src/allegro_hand_description/allegro_hand_description_right.xacro
...
```