### PR TITLE
allegro_hand: Fix typo in launch file; update spelling of state pub node

### DIFF
--- a/src/allegro_hand/launch/allegro_hand.launch
+++ b/src/allegro_hand/launch/allegro_hand.launch
@@ -123,7 +123,7 @@
   <!-- Joint States (angles) to Joint Transforms -->
   <node name="jointState2tf_$(arg NUM)"
         pkg="robot_state_publisher"
-        type="state_publisher">
+        type="robot_state_publisher">
     <remap from="tf" to="allegroHand_$(arg NUM)/tf"/>
     <remap from="joint_states" to="allegroHand_$(arg NUM)/joint_states"/>
   </node>

--- a/src/allegro_hand/launch/allegro_hand.launch
+++ b/src/allegro_hand/launch/allegro_hand.launch
@@ -131,7 +131,7 @@
   <!-- Keyboard handler (if arg KEYBOARD is true) -->
   <node name="keyboard_$(arg NUM)"
         pkg="allegro_hand_keyboard"
-        type="allegro_hand_keyboard_node"
+        type="allegro_hand_keyboard"
         output="screen"
         if="$(arg KEYBOARD)">
     <remap from="allegroHand/lib_cmd" to="allegroHand_$(arg NUM)/lib_cmd"/>

--- a/src/allegro_hand_controllers/launch/allegro_hand.launch
+++ b/src/allegro_hand_controllers/launch/allegro_hand.launch
@@ -123,7 +123,7 @@
   <!-- Joint States (angles) to Joint Transforms -->
   <node name="jointState2tf_$(arg NUM)"
         pkg="robot_state_publisher"
-        type="state_publisher">
+        type="robot_state_publisher">
     <remap from="tf" to="allegroHand_$(arg NUM)/tf"/>
     <remap from="joint_states" to="allegroHand_$(arg NUM)/joint_states"/>
   </node>
@@ -150,7 +150,7 @@
 
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
-	args="-urdf -model rrbot -param robot_description"
+  args="-urdf -model rrbot -param robot_description"
         if="$(arg GAZEBO)" />
 
 </launch>


### PR DESCRIPTION
Without fixed typo, error:
```
ERROR: cannot launch node of type [allegro_hand_keyboard/allegro_hand_keyboard_node]: Cannot locate node of type [allegro_hand_keyboard_node] in package [allegro_hand_keyboard]. Make sure file exists in package path and permission is set to executable (chmod +x)
```

Without updated spelling, warning:
```
[ WARN] ...: The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead
```